### PR TITLE
new parallelization

### DIFF
--- a/python/redmonster/physics/zpicker2.py
+++ b/python/redmonster/physics/zpicker2.py
@@ -105,7 +105,7 @@ class ZPicker:
             npixsteptuple = ()
             fstuple = ()
             # Catch spectra that are all 0's and return null result
-            if len(n.where(self.flux[ifiber] != 0)[0]) == 0 or len(n.where(self.ivar[ifiber] != 0)[0]) == 0:
+            if len(n.where(self.flux[0] != 0)[0]) == 0:
                 ztuple = (-1,)*self.num_z
                 zerrtuple = (-1,)*self.num_z
                 fnametuple = ('noSpectrum',)*self.num_z
@@ -135,11 +135,17 @@ class ZPicker:
                             fiberminvecs.append(
                                     zfitobjs[itemp].minvectors[ifiber][imin])
                         except IndexError as e:
-                            print "%r" % e
-                            fibermins.append( \
-                                    n.max(zfitobjs[itemp].chi2vals[ifiber]) / \
-                                    (self.dof[ifiber] - zfindobjs[itemp].npoly))
+                            #print "%r" % e
+                            #fibermins.append( \
+                            #        n.max(zfitobjs[itemp].chi2vals[ifiber]) / \
+                            #        (self.dof[ifiber] - zfindobjs[itemp].npoly))
+                            
+                            # this is ok, might be no solution
+                            #print "WARNING no z fitted for fiber #%d, class #%d, zid #%d"%(ifiber,itemp,imin)
+                            
+                            fibermins.append(100000.)
                             fiberminvecs.append( (-1,) )
+                            
                 # Build tuples of num_z best redshifts and classifications
                 # for this fiber
                 #for iz in xrange(self.num_z):


### PR DESCRIPTION
- instead of parallelizing redmonster in the desispec wrapper, the parallelization is now done in the loop over the templates of a given class for each input spectrum.
- this version works with a modified wrapper in desispec branch redmonster_fix
- a bug has also been fixed when an IndexError is raised in the situation where no refined redshift is found for a given template class (I checked the best redshift/class from the other template classes is still return correctly).
- I have not tried to remove totally the template dir from git, I know some tools exist, but I don't whether this would break the github fork or not.
- Nonetheless, we need to remove the tempates from git (it's very heavy to download all templates and their history when doing a git clone). Can someone try this, @weaverba137 ?
- I copied the templates to NERSC in 
  `/project/projectdirs/desi/spectro/templates/redmonster/v0.0`
- I also copied a lighter version of the templates in 
  `/project/projectdirs/desi/spectro/templates/redmonster/v0.1` . 
  This was done by @cballand. See the README file there.

In summary, to test this branch at NERSC, also do
- a checkout of desispec branch redmonster_fix
- set the environment variable 
  `export REDMONSTER_TEMPLATES_DIR=/project/projectdirs/desi/spectro/templates/redmonster/v0.1`

Example on edison at NERSC (don't forget to be on this branch of redmonster, branch redmonster_fix of desispec, and to modify REDMONSTER_TEMPLATES_DIR )

```
desi_zfind /scratch1/scratchdirs/sjbailey/desi/spectro/redux/hemlock/bricks/3331p200/brick-*.fits -o zbest-test.fits --nproc 24 --nspec 10
```
