### PR TITLE
fixed zwarning flagging bug

### DIFF
--- a/python/redmonster/physics/zpicker2.py
+++ b/python/redmonster/physics/zpicker2.py
@@ -213,7 +213,8 @@ class ZPicker:
                     if (c_kms*n.abs(self.z[ifiber][0] - self.z[ifiber][1])) / \
                             (1 + self.z[ifiber][0]) > 1000:
                         self.flag_small_dchi2(ifiber)
-                self.flag_small_dchi2(ifiber)
+                else:
+                    self.flag_small_dchi2(ifiber)
             if n.isnan(self.rchi2diff[ifiber]):
                 self.flag_small_dchi2(ifiber)
             self.flag_null_fit(ifiber, flags)


### PR DESCRIPTION
Fixed a bug where spectra were being given a SMALL_DELTA_CHI2 flag when two different templates had drchi2 < drchi2_threshold but the same redshift.  Given that redshift and not object type is the primary measurement, these cases should not be flagged.
